### PR TITLE
add query vagueness analysis and clarification nodes with prompts

### DIFF
--- a/backend/llm_models.py
+++ b/backend/llm_models.py
@@ -4,7 +4,9 @@ Pydantic models for LLM structured output parsing.
 from pydantic import BaseModel, Field, field_validator
 from typing import List, Optional, Dict
 
-
+class QueryVaguenessAnalysis(BaseModel):
+    """Structured output for query analysis."""
+    is_vague: bool = Field(description="True if the query is vague or ambiguous")
 
 class MultiSourceAnalysis(BaseModel):
     """Structured output for multi-source search analysis."""

--- a/backend/nodes/base.py
+++ b/backend/nodes/base.py
@@ -27,6 +27,10 @@ from services.personalization_manager import PersonalizationManager
 
 # Import all prompt templates from prompts.py
 from prompts import (
+    # Query vagueness analysis prompts
+    QUERY_VAGUENESS_ANALYSIS_PROMPT,
+    # Clarification prompts
+    CLARIFICATION_PROMPT,
     # Multi-source analyzer prompts
     MULTI_SOURCE_SYSTEM_PROMPT,
     # Search prompts
@@ -44,6 +48,7 @@ from prompts import (
 
 # Internal imports - LLM models
 from llm_models import (
+    QueryVaguenessAnalysis,
     MultiSourceAnalysis,
     AnalysisTask,
     FormattedResponse,
@@ -66,6 +71,7 @@ class ChatState(TypedDict):
     """Type definition for the chat state that flows through the graph."""
 
     messages: Annotated[List[BaseMessage], "The messages in the conversation using LangChain core message types"]
+    query_clarity: Annotated[Optional[bool], "Indicates if the user's query is clear or vague"]
     model: Annotated[str, "The model to use for the conversation"]
     temperature: Annotated[float, "The temperature to use for generation"]
     max_tokens: Annotated[int, "The maximum number of tokens to generate"]

--- a/backend/nodes/clarifier_node.py
+++ b/backend/nodes/clarifier_node.py
@@ -1,0 +1,63 @@
+"""
+Node for clarifying vague or ambiguous user queries.
+"""
+import asyncio
+from nodes.base import (
+    ChatState,
+    logger,
+    ChatOpenAI,
+    config,
+    HumanMessage,
+    AIMessage,
+    SystemMessage,
+    CLARIFICATION_PROMPT
+)
+from utils import get_last_user_message
+
+async def clarifier_node(state: ChatState) -> ChatState:
+    """Clarifies vague or ambiguous user queries"""
+    logger.info("❓ Clarification Node: Checking if query needs clarification")
+    await asyncio.sleep(0.1) #Small delay to ensure status is visible
+
+    # Get the last user message
+    last_message = get_last_user_message(state.get("messages", []))
+
+    clarifying_llm = ChatOpenAI(
+        model=config.ROUTER_MODEL,
+        temperature=0.0, # Keep deterministic
+        max_tokens=200,
+        api_key=config.OPENAI_API_KEY,
+    )
+
+    try:
+        history_messages = state.get("messages", [])
+
+        # Create the system prompt for clarification - include memory context if available
+        memory_context = state.get("memory_context")
+        memory_context_section = ""
+        if memory_context:
+            memory_context_section = f"CONVERSATION MEMORY:\n{memory_context}\n\nUse this context to maintain conversation continuity and reference previous topics when relevant."
+            logger.debug("❓ Clarification Node: Including memory context in analysis")
+        else:
+            logger.debug("❓ Clarification Node: No memory context available")
+
+        # Create system message with clarification instructions
+        system_message = SystemMessage(
+            content=CLARIFICATION_PROMPT.format(
+                memory_context_section=memory_context_section,
+                last_message=last_message)
+            )
+
+        # Build the complete message list for the clarifier
+        clarifier_messages = [system_message] + history_messages
+
+        response = clarifying_llm.invoke(clarifier_messages)
+        print(response.content)
+        logger.info("❓ Clarification Node: Generated clarification response")
+        state["workflow_context"]["clarifying_question"] = response.content
+        ai_response = AIMessage(content=response.content)
+        state["messages"].append(ai_response)
+    except Exception as e:
+        logger.error(f"Error in clarification_node: {str(e)}")
+
+    return state

--- a/backend/nodes/query_vagueness_analyzer_node.py
+++ b/backend/nodes/query_vagueness_analyzer_node.py
@@ -1,0 +1,85 @@
+"""
+Node for analyzing user queries for vagueness or ambiguity.
+"""
+import asyncio
+from nodes.base import (
+    ChatState,
+    logger,
+    ChatOpenAI,
+    config,
+    QueryVaguenessAnalysis,
+    QUERY_VAGUENESS_ANALYSIS_PROMPT,
+    HumanMessage,
+    SystemMessage
+)
+from utils import get_last_user_message
+
+async def query_vagueness_analyzer_node(state: ChatState) -> ChatState:
+    """Checks for vagueness or ambiguity in the user's query"""
+    logger.info("❓ Query Analysis: Analyzing query for vagueness or ambiguity")
+    await asyncio.sleep(0.1) # Small delay to ensure status is visible
+    
+    # Get the last user message
+    last_message = get_last_user_message(state.get("messages", []))
+
+    if not last_message:
+        state["intent"] = "chat"
+        state["selected_sources"] = []
+        ## ############state["routing_analysis"] =
+    analyzer_llm = ChatOpenAI(
+        model=config.ROUTER_MODEL,
+        temperature=0.0, # Keep deterministic
+        max_tokens=200,
+        api_key=config.OPENAI_API_KEY,
+    )
+
+    # Create a structured output model
+    structured_analyzer = analyzer_llm.with_structured_output(QueryVaguenessAnalysis)
+
+    try:
+        history_messages = state.get("messages", [])
+
+        # Create the system prompt for analysis - include memory context if available
+        memory_context = state.get("memory_context")
+        memory_context_section = ""
+        if memory_context:
+            memory_context_section = f"CONVERSATION MEMORY:\n{memory_context}\n\nUse this context to maintain conversation continuity and reference previous topics when relevant."
+            logger.debug("❓ Multi-Source Analyzer: Including memory context in analysis")
+        else:
+            logger.debug("❓ Multi-Source Analyzer: No memory context available")
+
+        # Create system message with analysis instructions
+        system_message = SystemMessage(
+            content=QUERY_VAGUENESS_ANALYSIS_PROMPT.format(
+                memory_context_section=memory_context_section
+            )
+        )
+
+        # Build the complete message list for the analyzer
+        analyzer_messages = [system_message] + history_messages
+
+        # If no conversation history exists, add the current user message
+        if not history_messages and last_message:
+            analyzer_messages.append(HumanMessage(content=last_message))
+
+        logger.debug(f"Query vagueness analyzer using {len(analyzer_messages)-1} context messages")
+
+        # Invoke the structured analyzer
+        analysis_result = structured_analyzer.invoke(analyzer_messages)
+
+        # Extract results
+        query_is_clear = not analysis_result.is_vague
+
+        if query_is_clear:
+            state["query_clarity"] = True
+            logger.info("❓ Query Analysis: Query is clear and specific, skipping clarifier")
+        else:
+            state["query_clarity"] = False
+            logger.info("❓ Query Analysis: Query is vague or ambiguous, heading to clarifier")
+    except Exception as e:
+        # Error handling with fallback to query_clarity = True
+        logger.error(f"Error in query_vagueness_analyzer_node: {str(e)}")
+        state["query_clarity"] = True
+        logger.info("❓ Query Analysis: Exception occurred, defaulting to chat")
+    
+    return state

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -3,6 +3,46 @@ Contains all prompts used by LLMs throughout the system.
 Each prompt is defined as a string template that can be formatted with dynamic values.
 """
 
+# Query-analyzer prompt
+QUERY_VAGUENESS_ANALYSIS_PROMPT = """
+You are an intelligent query analyzer that decides whether the user’s prompt is ambiguous, vague or not.
+
+Analyze the conversation to determine if it is ambiguous/vague or not.
+
+1. **True** -
+- If the user's query scope is too wide to narrow down.
+- If the user's query is ambiguous.
+- If the user's query is vague
+
+2. **False** -
+- If the user's query is clear from the get go.
+- If the user's query is related to previous conversations in memory.
+
+{memory_context_section}
+"""
+
+# Clarification prompt
+CLARIFICATION_PROMPT = """
+You are an intelligent assistant that helps users clarify vague or ambiguous queries.
+
+{memory_context_section}
+
+The user's last query was:
+"{last_message}"
+
+Your task:
+Generate exactly one short clarifying question to help the user make their intent clearer.
+Use simple A/B/C shortcut options for faster response. The options shouldn't exceed three.
+Do not attempt to answer the query — only ask the clarifying question.
+
+Example format:
+"Could you clarify whether you meant Apple —
+A. the company
+B. the fruit
+C. the product
+Feel free to use the letters as shortcuts. If it's none of the above, please let me know."
+"""
+
 
 # Multi-source analyzer prompts
 MULTI_SOURCE_SYSTEM_PROMPT = """

--- a/static/diagrams/flow_metadata.json
+++ b/static/diagrams/flow_metadata.json
@@ -1,0 +1,355 @@
+{
+  "main_chat_flow": {
+    "type": "main",
+    "nodes": [
+      {
+        "id": "initializer",
+        "type": "start",
+        "prompt": null,
+        "category": "System",
+        "description": "Sets up user state and session",
+        "color": "#E8F4FD"
+      },
+      {
+        "id": "multi_source_analyzer",
+        "type": "decision",
+        "prompt": "MULTI_SOURCE_SYSTEM_PROMPT",
+        "category": "Analyzer",
+        "description": "Analyzes queries and selects information sources",
+        "color": "#FFE6E6"
+      },
+      {
+        "id": "search_prompt_optimizer",
+        "type": "process",
+        "prompt": "SEARCH_OPTIMIZER_SYSTEM_PROMPT",
+        "category": "Search",
+        "description": "Optimizes search queries",
+        "color": "#E6F3FF"
+      },
+      {
+        "id": "analysis_task_refiner",
+        "type": "process",
+        "prompt": "ANALYSIS_REFINER_SYSTEM_PROMPT",
+        "category": "Analysis",
+        "description": "Refines analysis tasks",
+        "color": "#E6FFE6"
+      },
+      {
+        "id": "search",
+        "type": "process",
+        "prompt": "PERPLEXITY_SYSTEM_PROMPT",
+        "category": "Search",
+        "description": "Performs web search",
+        "color": "#E6F3FF"
+      },
+      {
+        "id": "analyzer",
+        "type": "process",
+        "prompt": null,
+        "category": "Analysis",
+        "description": "Analyzes data and problems",
+        "color": "#E6FFE6"
+      },
+      {
+        "id": "integrator",
+        "type": "process",
+        "prompt": "INTEGRATOR_SYSTEM_PROMPT",
+        "category": "Integrator",
+        "description": "Integrates all information",
+        "color": "#F0E6FF"
+      },
+      {
+        "id": "response_renderer",
+        "type": "end",
+        "prompt": "RESPONSE_RENDERER_SYSTEM_PROMPT",
+        "category": "Response",
+        "description": "Formats final response",
+        "color": "#FFF0E6"
+      }
+    ],
+    "edges": [
+      {
+        "from": "initializer",
+        "to": "multi_source_analyzer"
+      },
+      {
+        "from": "multi_source_analyzer",
+        "to": "search_prompt_optimizer",
+        "condition": "search"
+      },
+      {
+        "from": "multi_source_analyzer",
+        "to": "analysis_task_refiner",
+        "condition": "analysis"
+      },
+      {
+        "from": "multi_source_analyzer",
+        "to": "integrator",
+        "condition": "chat"
+      },
+      {
+        "from": "search_prompt_optimizer",
+        "to": "search"
+      },
+      {
+        "from": "search",
+        "to": "integrator"
+      },
+      {
+        "from": "analysis_task_refiner",
+        "to": "analyzer"
+      },
+      {
+        "from": "analyzer",
+        "to": "integrator"
+      },
+      {
+        "from": "integrator",
+        "to": "response_renderer"
+      }
+    ],
+    "node_count": 8,
+    "edge_count": 9
+  },
+  "research_flow": {
+    "type": "research",
+    "nodes": [
+      {
+        "id": "research_initializer",
+        "type": "start",
+        "prompt": null,
+        "category": "Research",
+        "description": "Initializes research workflow",
+        "color": "#F0F8E6"
+      },
+      {
+        "id": "research_query_generator",
+        "type": "process",
+        "prompt": "RESEARCH_QUERY_GENERATION_PROMPT",
+        "category": "Research",
+        "description": "Generates research queries",
+        "color": "#F0F8E6"
+      },
+      {
+        "id": "research_source_selector",
+        "type": "process"
+      },
+      {
+        "id": "source_coordinator",
+        "type": "process"
+      },
+      {
+        "id": "integrator",
+        "type": "process",
+        "prompt": "INTEGRATOR_SYSTEM_PROMPT",
+        "category": "Integrator",
+        "description": "Integrates all information",
+        "color": "#F0E6FF"
+      },
+      {
+        "id": "response_renderer",
+        "type": "process",
+        "prompt": "RESPONSE_RENDERER_SYSTEM_PROMPT",
+        "category": "Response",
+        "description": "Formats final response",
+        "color": "#FFF0E6"
+      },
+      {
+        "id": "research_quality_assessor",
+        "type": "process",
+        "prompt": "RESEARCH_FINDINGS_QUALITY_ASSESSMENT_PROMPT",
+        "category": "Research",
+        "description": "Assesses research quality",
+        "color": "#F0F8E6"
+      },
+      {
+        "id": "research_deduplication",
+        "type": "process",
+        "prompt": "RESEARCH_FINDINGS_DEDUPLICATION_PROMPT",
+        "category": "Research",
+        "description": "Checks for duplicates",
+        "color": "#F0F8E6"
+      },
+      {
+        "id": "research_storage",
+        "type": "end",
+        "prompt": null,
+        "category": "Research",
+        "description": "Stores research findings",
+        "color": "#F0F8E6"
+      }
+    ],
+    "edges": [
+      {
+        "from": "research_initializer",
+        "to": "research_query_generator"
+      },
+      {
+        "from": "research_query_generator",
+        "to": "research_source_selector"
+      },
+      {
+        "from": "research_source_selector",
+        "to": "source_coordinator"
+      },
+      {
+        "from": "source_coordinator",
+        "to": "integrator"
+      },
+      {
+        "from": "integrator",
+        "to": "response_renderer"
+      },
+      {
+        "from": "response_renderer",
+        "to": "research_quality_assessor"
+      },
+      {
+        "from": "research_quality_assessor",
+        "to": "research_deduplication"
+      },
+      {
+        "from": "research_deduplication",
+        "to": "research_storage"
+      }
+    ],
+    "node_count": 9,
+    "edge_count": 8
+  },
+  "flow_summary": {
+    "flows": {
+      "main_chat": {
+        "node_count": 8,
+        "edge_count": 9,
+        "type": "conditional"
+      },
+      "research": {
+        "node_count": 9,
+        "edge_count": 8,
+        "type": "linear"
+      }
+    },
+    "prompt_usage": {
+      "MULTI_SOURCE_SYSTEM_PROMPT": [
+        "multi_source_analyzer"
+      ],
+      "SEARCH_OPTIMIZER_SYSTEM_PROMPT": [
+        "search_prompt_optimizer"
+      ],
+      "ANALYSIS_REFINER_SYSTEM_PROMPT": [
+        "analysis_task_refiner"
+      ],
+      "PERPLEXITY_SYSTEM_PROMPT": [
+        "search"
+      ],
+      "INTEGRATOR_SYSTEM_PROMPT": [
+        "integrator"
+      ],
+      "RESPONSE_RENDERER_SYSTEM_PROMPT": [
+        "response_renderer"
+      ],
+      "RESEARCH_QUERY_GENERATION_PROMPT": [
+        "research_query_generator"
+      ],
+      "RESEARCH_FINDINGS_QUALITY_ASSESSMENT_PROMPT": [
+        "research_quality_assessor"
+      ],
+      "RESEARCH_FINDINGS_DEDUPLICATION_PROMPT": [
+        "research_deduplication"
+      ]
+    },
+    "category_distribution": {
+      "System": 1,
+      "Analyzer": 1,
+      "Search": 2,
+      "Analysis": 2,
+      "Integrator": 2,
+      "Response": 2,
+      "Research": 5,
+      "Unknown": 2
+    },
+    "total_nodes": 17,
+    "total_prompts": 9
+  },
+  "node_prompt_mapping": {
+    "initializer": {
+      "prompt": null,
+      "category": "System",
+      "description": "Sets up user state and session",
+      "color": "#E8F4FD"
+    },
+    "multi_source_analyzer": {
+      "prompt": "MULTI_SOURCE_SYSTEM_PROMPT",
+      "category": "Analyzer",
+      "description": "Analyzes queries and selects information sources",
+      "color": "#FFE6E6"
+    },
+    "search_prompt_optimizer": {
+      "prompt": "SEARCH_OPTIMIZER_SYSTEM_PROMPT",
+      "category": "Search",
+      "description": "Optimizes search queries",
+      "color": "#E6F3FF"
+    },
+    "analysis_task_refiner": {
+      "prompt": "ANALYSIS_REFINER_SYSTEM_PROMPT",
+      "category": "Analysis",
+      "description": "Refines analysis tasks",
+      "color": "#E6FFE6"
+    },
+    "search": {
+      "prompt": "PERPLEXITY_SYSTEM_PROMPT",
+      "category": "Search",
+      "description": "Performs web search",
+      "color": "#E6F3FF"
+    },
+    "analyzer": {
+      "prompt": null,
+      "category": "Analysis",
+      "description": "Analyzes data and problems",
+      "color": "#E6FFE6"
+    },
+    "integrator": {
+      "prompt": "INTEGRATOR_SYSTEM_PROMPT",
+      "category": "Integrator",
+      "description": "Integrates all information",
+      "color": "#F0E6FF"
+    },
+    "response_renderer": {
+      "prompt": "RESPONSE_RENDERER_SYSTEM_PROMPT",
+      "category": "Response",
+      "description": "Formats final response",
+      "color": "#FFF0E6"
+    },
+    "research_initializer": {
+      "prompt": null,
+      "category": "Research",
+      "description": "Initializes research workflow",
+      "color": "#F0F8E6"
+    },
+    "research_query_generator": {
+      "prompt": "RESEARCH_QUERY_GENERATION_PROMPT",
+      "category": "Research",
+      "description": "Generates research queries",
+      "color": "#F0F8E6"
+    },
+    "research_quality_assessor": {
+      "prompt": "RESEARCH_FINDINGS_QUALITY_ASSESSMENT_PROMPT",
+      "category": "Research",
+      "description": "Assesses research quality",
+      "color": "#F0F8E6"
+    },
+    "research_deduplication": {
+      "prompt": "RESEARCH_FINDINGS_DEDUPLICATION_PROMPT",
+      "category": "Research",
+      "description": "Checks for duplicates",
+      "color": "#F0F8E6"
+    },
+    "research_storage": {
+      "prompt": null,
+      "category": "Research",
+      "description": "Stores research findings",
+      "color": "#F0F8E6"
+    }
+  },
+  "generated_at": 1760551542.154899
+}


### PR DESCRIPTION
Enhances Qwestor’s search flow with vagueness detection and clarification handling. Adds a query_vagueness_analyzer_node to detect unclear user queries and route them to the clarifier_node for LLM-assisted clarification. The clarified response passes through the standard integrator → response_renderer pipeline for consistency.

Key changes:

Added query_vagueness_analyzer_node for query clarity analysis.

Integrated clarifier_node with structured prompt for generating clarifying questions.

Updated graph routing logic to handle vague vs. clear query paths.

Maintained unified output flow through integrator for consistent rendering.